### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MBSegueCollection is a growing collection of different custom segues for iOS 6 or later. All segues can be used to present or to dismiss view controllers.
 
-[![Build Status](https://img.shields.io/travis/mathebox/MBSegueCollection.svg?style=flat)](https://travis-ci.org/mathebox/MBSegueCollection) [![Cocoapods](https://img.shields.io/cocoapods/v/MBSegueCollection.svg?style=flat)](http://cocoapods.org/?q=mbseguecollection) ![Platform](https://img.shields.io/cocoapods/p/MBSegueCollection.svg?style=flat) ![License](https://img.shields.io/cocoapods/l/MBSegueCollection.svg?style=flat)
+[![Build Status](https://img.shields.io/travis/mathebox/MBSegueCollection.svg?style=flat)](https://travis-ci.org/mathebox/MBSegueCollection) [![CocoaPods](https://img.shields.io/cocoapods/v/MBSegueCollection.svg?style=flat)](http://cocoapods.org/?q=mbseguecollection) ![Platform](https://img.shields.io/cocoapods/p/MBSegueCollection.svg?style=flat) ![License](https://img.shields.io/cocoapods/l/MBSegueCollection.svg?style=flat)
 
 # Install
 - Requirement: iOS 6


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
